### PR TITLE
Manage patch state at window level

### DIFF
--- a/src/helpers/patch_function.ts
+++ b/src/helpers/patch_function.ts
@@ -1,7 +1,10 @@
+(window as any).cardMod_patch_state = (window as any).cardMod_patch_state || {};
+
+const patchState: Record<string, Boolean> = (window as any).cardMod_patch_state;
+
 const patch_method = function (obj, method, override) {
   if (method === "constructor") return;
   const original = obj[method];
-  if (original?.cm_patched) return;
 
   const fn = function (...args) {
     try {
@@ -11,7 +14,6 @@ const patch_method = function (obj, method, override) {
       return original?.bind(this)(...args);
     }
   };
-  fn.cm_patched = true;
   obj[method] = fn;
 };
 
@@ -35,6 +37,30 @@ export const patch_prototype = async (cls, patch, afterwards?) => {
 // Decorator for patching a custom-element
 export function patch_element(element, afterwards?) {
   return function patched(constructor) {
+    const key = typeof element === "string" ? element : element.name;
+    const patched = patchState[key] ?? false;
+    if (patched) {
+      patch_warning(key);
+      return;
+    }
+    patchState[key] = true;
     patch_prototype(element, constructor, afterwards);
   };
+}
+
+function patch_warning(key) {
+  if ((window as any).cm_patch_warning) return;
+  (window as any).cm_patch_warning = true;
+  console.groupCollapsed(
+    `%cCARD-MOD: ${key} already patched!`,
+    "color: red; font-weight: bold"
+  );
+  console.info("Card-mod likely loaded twice with different resource URLs.");
+  console.info(
+    "Make sure all card-mod resource URLs including hacstag match EXACTLY."
+  );
+  console.info(
+    "Also check other custom elemets inculding cards and themes which may load card-mod."
+  );
+  console.groupEnd();
 }


### PR DESCRIPTION
```console
CARD-MOD: ha-card already patched!
 Card-mod likely loaded twice with different resource URLs. 
 Make sure all card-mod resource URLs including hacstag match EXACTLY.
 Also check other custom elemets inculding cards and themes which may load card-mod.
```

Previously patching was recorded at function level which is too late when patching takes place in a 2nd running copy. This change protects and warns of that condition which is very hard to debug and review with users.